### PR TITLE
feat: Add Route mode + SQLite persistence, closes #15 #16

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"expo-keep-awake": "~14.0.3",
 		"expo-location": "~18.0.10",
 		"expo-sharing": "~13.0.0",
+		"expo-sqlite": "^55.0.11",
 		"expo-status-bar": "~2.0.1",
 		"fast-xml-parser": "^4.4.0",
 		"lucide-react-native": "^0.577.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       expo-sharing:
         specifier: ~13.0.0
         version: 13.0.1(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))
+      expo-sqlite:
+        specifier: ^55.0.11
+        version: 55.0.11(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       expo-status-bar:
         specifier: ~2.0.1
         version: 2.0.1(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
@@ -891,7 +894,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.22.28':
     resolution: {integrity: sha512-lvt72KNitGuixYD2l3SZmRKVu2G4zJpmg5V7WfUBNpmUU5oODBw/6qmiJ6kSLAlfDozscUk+BBGknBBzxUrwrA==}
@@ -1376,6 +1379,9 @@ packages:
   at-least-node@1.0.0:
     resolution: {integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==}
     engines: {node: '>= 4.0.0'}
+
+  await-lock@2.2.2:
+    resolution: {integrity: sha512-aDczADvlvTGajTDjcjpJMqRkOF6Qdz3YbPZm/PyW6tKPkx2hlYBzxMhEywM/tU72HrVZjgl5VCdRuMlA7pZ8Gw==}
 
   babel-core@7.0.0-bridge.0:
     resolution: {integrity: sha512-poPX9mZH/5CSanm50Q+1toVci6pv5KSRv/5TWCwtzQS5XEwn40BcCrgIeMFWP9CKKIniKXNxoIOnOq4VVlGXhg==}
@@ -1981,6 +1987,13 @@ packages:
     resolution: {integrity: sha512-qych3Nw65wlFcnzE/gRrsdtvmdV0uF4U4qVMZBJYPG90vYyWh2QM9rp1gVu0KWOBc7N8CC2dSVYn4/BXqJy6Xw==}
     peerDependencies:
       expo: '*'
+
+  expo-sqlite@55.0.11:
+    resolution: {integrity: sha512-lDGJrE0m1lw/3y1ZSsER2kfXnS+9WzgaKcIFp/RKbTfyhs0v8l86Ulqdr+6peRFOfzi0kdj4Ty0LzE2Adx93tg==}
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo-status-bar@2.0.1:
     resolution: {integrity: sha512-AkIPX7jWHRPp83UBZ1iXtVvyr0g+DgBVvIXTtlmPtmUsm8Vq9Bb5IGj86PW8osuFlgoTVAg7HI/+Ok7yEYwiRg==}
@@ -5529,6 +5542,8 @@ snapshots:
 
   at-least-node@1.0.0: {}
 
+  await-lock@2.2.2: {}
+
   babel-core@7.0.0-bridge.0(@babel/core@7.29.0):
     dependencies:
       '@babel/core': 7.29.0
@@ -6202,6 +6217,13 @@ snapshots:
   expo-sharing@13.0.1(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)):
     dependencies:
       expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+
+  expo-sqlite@55.0.11(expo@52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      await-lock: 2.2.2
+      expo: 52.0.49(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-native: 0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1)
 
   expo-status-bar@2.0.1(react-native@0.76.5(@babel/core@7.29.0)(@babel/preset-env@7.29.2(@babel/core@7.29.0))(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/src/components/AddRouteButton.tsx
+++ b/src/components/AddRouteButton.tsx
@@ -1,0 +1,42 @@
+import { Plus } from 'lucide-react-native';
+import { StyleSheet, Text, TouchableOpacity } from 'react-native';
+import { useRouteStore } from '../store/routeStore';
+
+export default function AddRouteButton() {
+	const setEditingMode = useRouteStore((s) => s.setEditingMode);
+
+	return (
+		<TouchableOpacity
+			style={styles.button}
+			onPress={() => setEditingMode('creating')}
+			activeOpacity={0.85}
+		>
+			<Plus size={20} color="#fff" />
+			<Text style={styles.label}>Add Route</Text>
+		</TouchableOpacity>
+	);
+}
+
+const styles = StyleSheet.create({
+	button: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: 8,
+		backgroundColor: '#2563eb',
+		borderRadius: 12,
+		paddingVertical: 14,
+		marginHorizontal: 16,
+		marginTop: 12,
+		shadowColor: '#000',
+		shadowOffset: { width: 0, height: 2 },
+		shadowOpacity: 0.15,
+		shadowRadius: 4,
+		elevation: 4,
+	},
+	label: {
+		color: '#fff',
+		fontSize: 15,
+		fontWeight: '700',
+	},
+});

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -3,7 +3,7 @@ import MapLibreGL, { type MapViewRef } from '@maplibre/maplibre-react-native';
 import * as DocumentPicker from 'expo-document-picker';
 import * as FileSystem from 'expo-file-system';
 import type React from 'react';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	ActivityIndicator,
 	Alert,
@@ -19,10 +19,18 @@ import {
 	OFFLINE_MIN_ZOOM,
 	OFFLINE_TILE_URL,
 } from '../constants/map';
+import {
+	deleteRoute,
+	initDb,
+	listRoutes,
+	type SavedRoute,
+} from '../services/db';
 import { exportGpx } from '../services/gpxExport';
 import { parseGpx } from '../services/gpxParser';
 import { useRouteStore } from '../store/routeStore';
+import AddRouteButton from './AddRouteButton';
 import ElevationProfile from './ElevationProfile';
+import RouteActionBar from './RouteActionBar';
 
 interface Props {
 	mapViewRef: React.RefObject<MapViewRef>;
@@ -33,6 +41,7 @@ export default function ControlsPanel({ mapViewRef }: Props) {
 	const bottomSheetRef = useRef<BottomSheet>(null);
 	const { width } = useWindowDimensions();
 
+	const editingMode = useRouteStore((s) => s.editingMode);
 	const waypoints = useRouteStore((s) => s.waypoints);
 	const route = useRouteStore((s) => s.route);
 	const routeStats = useRouteStore((s) => s.routeStats);
@@ -40,9 +49,22 @@ export default function ControlsPanel({ mapViewRef }: Props) {
 	const setIsSnapping = useRouteStore((s) => s.setIsSnapping);
 	const loadWaypoints = useRouteStore((s) => s.loadWaypoints);
 
+	const isCreating = editingMode === 'creating';
+
+	const [savedRoutes, setSavedRoutes] = useState<SavedRoute[]>([]);
 	const [offlineProgress, setOfflineProgress] = useState<number | null>(null);
 	const [isExporting, setIsExporting] = useState(false);
 	const [isImporting, setIsImporting] = useState(false);
+
+	// Initialise DB and load saved routes on mount
+	useEffect(() => {
+		initDb();
+		setSavedRoutes(listRoutes());
+	}, []);
+
+	const refreshRoutes = useCallback(() => {
+		setSavedRoutes(listRoutes());
+	}, []);
 
 	// ── GPX Export ─────────────────────────────────────────────────────────────
 	const handleExport = useCallback(async () => {
@@ -157,6 +179,20 @@ export default function ControlsPanel({ mapViewRef }: Props) {
 		}
 	}, [mapViewRef]);
 
+	const handleDeleteRoute = useCallback((id: number) => {
+		Alert.alert('Delete route', 'This route will be permanently deleted.', [
+			{ text: 'Cancel', style: 'cancel' },
+			{
+				text: 'Delete',
+				style: 'destructive',
+				onPress: () => {
+					deleteRoute(id);
+					setSavedRoutes(listRoutes());
+				},
+			},
+		]);
+	}, []);
+
 	const hasRoute = route !== null;
 	const hasWaypoints = waypoints.length > 0;
 
@@ -168,25 +204,66 @@ export default function ControlsPanel({ mapViewRef }: Props) {
 			backgroundStyle={styles.sheet}
 			handleIndicatorStyle={styles.handle}
 		>
+			{/* Creating mode: action bar replaces the handle area */}
+			{isCreating && <RouteActionBar onRouteSaved={refreshRoutes} />}
+
 			<BottomSheetScrollView contentContainerStyle={styles.content}>
-				{/* Hint when no waypoints */}
-				{!hasWaypoints && (
-					<Text style={styles.hint}>Long-press the map to add waypoints</Text>
+				{/* View mode ── saved routes list + Add Route button */}
+				{!isCreating && (
+					<>
+						{savedRoutes.length > 0 && (
+							<View style={styles.savedSection}>
+								<Text style={styles.sectionTitle}>Saved Routes</Text>
+								{savedRoutes.map((r) => (
+									<View key={r.id} style={styles.savedRow}>
+										<View style={styles.savedInfo}>
+											<Text style={styles.savedName}>{r.name}</Text>
+											{r.stats && (
+												<Text style={styles.savedMeta}>
+													{r.stats.distanceKm.toFixed(2)} km ·{' '}
+													{r.stats.gainM.toFixed(0)} m gain
+												</Text>
+											)}
+										</View>
+										<TouchableOpacity
+											style={styles.deleteBtn}
+											onPress={() => handleDeleteRoute(r.id)}
+										>
+											<Text style={styles.deleteBtnText}>Delete</Text>
+										</TouchableOpacity>
+									</View>
+								))}
+							</View>
+						)}
+
+						{savedRoutes.length === 0 && (
+							<Text style={styles.hint}>No saved routes yet</Text>
+						)}
+
+						<AddRouteButton />
+					</>
 				)}
 
-				{/* Elevation profile */}
-				{hasRoute && <ElevationProfile width={width} />}
-
-				{/* Route stats summary (compact, shown even when sheet is collapsed) */}
-				{routeStats && !hasRoute && (
-					<View style={styles.statsRow}>
-						<Text style={styles.statLabel}>
-							{routeStats.distanceKm.toFixed(2)} km
-						</Text>
-					</View>
+				{/* Creating mode ── elevation profile + stats */}
+				{isCreating && (
+					<>
+						{!hasWaypoints && (
+							<Text style={styles.hint}>
+								Long-press the map to add waypoints
+							</Text>
+						)}
+						{hasRoute && <ElevationProfile width={width} />}
+						{routeStats && !hasRoute && (
+							<View style={styles.statsRow}>
+								<Text style={styles.statLabel}>
+									{routeStats.distanceKm.toFixed(2)} km
+								</Text>
+							</View>
+						)}
+					</>
 				)}
 
-				{/* Controls */}
+				{/* Controls — visible in both modes */}
 				<View style={styles.controls}>
 					{/* Snap to trails toggle */}
 					<View style={styles.row}>
@@ -295,6 +372,50 @@ const styles = StyleSheet.create({
 		color: '#9ca3af',
 		fontSize: 13,
 		paddingVertical: 12,
+	},
+	savedSection: {
+		paddingHorizontal: 16,
+		paddingTop: 8,
+		gap: 6,
+	},
+	sectionTitle: {
+		fontSize: 13,
+		fontWeight: '700',
+		color: '#6b7280',
+		textTransform: 'uppercase',
+		letterSpacing: 0.5,
+		marginBottom: 2,
+	},
+	savedRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		paddingVertical: 8,
+		borderBottomWidth: StyleSheet.hairlineWidth,
+		borderBottomColor: '#e5e7eb',
+	},
+	savedInfo: {
+		flex: 1,
+	},
+	savedName: {
+		fontSize: 14,
+		fontWeight: '600',
+		color: '#111827',
+	},
+	savedMeta: {
+		fontSize: 12,
+		color: '#6b7280',
+		marginTop: 1,
+	},
+	deleteBtn: {
+		paddingHorizontal: 10,
+		paddingVertical: 5,
+		borderRadius: 6,
+		backgroundColor: '#fee2e2',
+	},
+	deleteBtnText: {
+		fontSize: 12,
+		fontWeight: '600',
+		color: '#dc2626',
 	},
 	statsRow: {
 		paddingHorizontal: 16,

--- a/src/components/NameRouteModal.tsx
+++ b/src/components/NameRouteModal.tsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import {
+	Modal,
+	StyleSheet,
+	Text,
+	TextInput,
+	TouchableOpacity,
+	View,
+} from 'react-native';
+
+interface Props {
+	visible: boolean;
+	onSave: (name: string) => void;
+	onCancel: () => void;
+}
+
+export default function NameRouteModal({ visible, onSave, onCancel }: Props) {
+	const [name, setName] = useState('');
+
+	function handleSave() {
+		const trimmed = name.trim();
+		if (!trimmed) return;
+		onSave(trimmed);
+		setName('');
+	}
+
+	function handleCancel() {
+		setName('');
+		onCancel();
+	}
+
+	return (
+		<Modal
+			visible={visible}
+			transparent
+			animationType="fade"
+			onRequestClose={handleCancel}
+		>
+			<View style={styles.overlay}>
+				<View style={styles.dialog}>
+					<Text style={styles.title}>Name this route</Text>
+					<TextInput
+						style={styles.input}
+						value={name}
+						onChangeText={setName}
+						placeholder="e.g. Morning Trail Loop"
+						placeholderTextColor="#9ca3af"
+						autoFocus
+						returnKeyType="done"
+						onSubmitEditing={handleSave}
+					/>
+					<View style={styles.row}>
+						<TouchableOpacity
+							style={[styles.btn, styles.cancelBtn]}
+							onPress={handleCancel}
+						>
+							<Text style={styles.cancelText}>Cancel</Text>
+						</TouchableOpacity>
+						<TouchableOpacity
+							style={[
+								styles.btn,
+								styles.saveBtn,
+								!name.trim() && styles.disabled,
+							]}
+							onPress={handleSave}
+							disabled={!name.trim()}
+						>
+							<Text style={styles.saveText}>Save</Text>
+						</TouchableOpacity>
+					</View>
+				</View>
+			</View>
+		</Modal>
+	);
+}
+
+const styles = StyleSheet.create({
+	overlay: {
+		flex: 1,
+		backgroundColor: 'rgba(0,0,0,0.45)',
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	dialog: {
+		width: '82%',
+		backgroundColor: '#fff',
+		borderRadius: 14,
+		padding: 20,
+		gap: 14,
+		shadowColor: '#000',
+		shadowOffset: { width: 0, height: 4 },
+		shadowOpacity: 0.2,
+		shadowRadius: 12,
+		elevation: 10,
+	},
+	title: {
+		fontSize: 17,
+		fontWeight: '700',
+		color: '#111827',
+		textAlign: 'center',
+	},
+	input: {
+		borderWidth: 1,
+		borderColor: '#d1d5db',
+		borderRadius: 8,
+		paddingHorizontal: 12,
+		paddingVertical: 10,
+		fontSize: 15,
+		color: '#111827',
+	},
+	row: {
+		flexDirection: 'row',
+		gap: 10,
+	},
+	btn: {
+		flex: 1,
+		paddingVertical: 11,
+		borderRadius: 8,
+		alignItems: 'center',
+	},
+	cancelBtn: {
+		backgroundColor: '#f3f4f6',
+	},
+	saveBtn: {
+		backgroundColor: '#2563eb',
+	},
+	disabled: {
+		opacity: 0.4,
+	},
+	cancelText: {
+		fontSize: 15,
+		fontWeight: '600',
+		color: '#374151',
+	},
+	saveText: {
+		fontSize: 15,
+		fontWeight: '700',
+		color: '#fff',
+	},
+});

--- a/src/components/RouteActionBar.tsx
+++ b/src/components/RouteActionBar.tsx
@@ -1,0 +1,169 @@
+import { Check, X } from 'lucide-react-native';
+import { useCallback, useState } from 'react';
+import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { saveRoute } from '../services/db';
+import { useRouteStore } from '../store/routeStore';
+import NameRouteModal from './NameRouteModal';
+
+interface Props {
+	onRouteSaved: () => void;
+}
+
+export default function RouteActionBar({ onRouteSaved }: Props) {
+	const waypoints = useRouteStore((s) => s.waypoints);
+	const route = useRouteStore((s) => s.route);
+	const routeStats = useRouteStore((s) => s.routeStats);
+	const clearAll = useRouteStore((s) => s.clearAll);
+	const setEditingMode = useRouteStore((s) => s.setEditingMode);
+
+	const [namingVisible, setNamingVisible] = useState(false);
+
+	const canSave = waypoints.length >= 2 && route !== null;
+
+	const handleSavePress = useCallback(() => {
+		if (!canSave) return;
+		setNamingVisible(true);
+	}, [canSave]);
+
+	const handleNameConfirm = useCallback(
+		(name: string) => {
+			if (!route) return;
+			try {
+				saveRoute(name, waypoints, route, routeStats);
+			} catch (err: unknown) {
+				Alert.alert(
+					'Save failed',
+					err instanceof Error ? err.message : String(err),
+				);
+				return;
+			}
+			setNamingVisible(false);
+			clearAll();
+			setEditingMode('view');
+			onRouteSaved();
+		},
+		[route, waypoints, routeStats, clearAll, setEditingMode, onRouteSaved],
+	);
+
+	const handleCancel = useCallback(() => {
+		if (waypoints.length === 0) {
+			clearAll();
+			setEditingMode('view');
+			return;
+		}
+		Alert.alert('Discard route?', 'All waypoints will be removed.', [
+			{ text: 'Keep editing', style: 'cancel' },
+			{
+				text: 'Discard',
+				style: 'destructive',
+				onPress: () => {
+					clearAll();
+					setEditingMode('view');
+				},
+			},
+		]);
+	}, [waypoints.length, clearAll, setEditingMode]);
+
+	return (
+		<>
+			<View style={styles.bar}>
+				<TouchableOpacity
+					style={styles.cancelButton}
+					onPress={handleCancel}
+					activeOpacity={0.8}
+				>
+					<X size={18} color="#374151" />
+					<Text style={styles.cancelLabel}>Cancel</Text>
+				</TouchableOpacity>
+
+				<View style={styles.hint}>
+					<Text style={styles.hintText}>
+						{waypoints.length === 0
+							? 'Long-press map to add waypoints'
+							: waypoints.length === 1
+								? 'Add one more waypoint'
+								: route
+									? 'Route ready to save'
+									: 'Computing route…'}
+					</Text>
+				</View>
+
+				<TouchableOpacity
+					style={[styles.saveButton, !canSave && styles.saveDisabled]}
+					onPress={handleSavePress}
+					disabled={!canSave}
+					activeOpacity={0.8}
+				>
+					<Check size={18} color={canSave ? '#fff' : '#9ca3af'} />
+					<Text
+						style={[styles.saveLabel, !canSave && styles.saveLabelDisabled]}
+					>
+						Save
+					</Text>
+				</TouchableOpacity>
+			</View>
+
+			<NameRouteModal
+				visible={namingVisible}
+				onSave={handleNameConfirm}
+				onCancel={() => setNamingVisible(false)}
+			/>
+		</>
+	);
+}
+
+const styles = StyleSheet.create({
+	bar: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		backgroundColor: '#fff',
+		paddingHorizontal: 12,
+		paddingVertical: 10,
+		borderTopWidth: 1,
+		borderTopColor: '#e5e7eb',
+		gap: 8,
+	},
+	cancelButton: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 4,
+		paddingVertical: 8,
+		paddingHorizontal: 10,
+		borderRadius: 8,
+		backgroundColor: '#f3f4f6',
+	},
+	cancelLabel: {
+		fontSize: 14,
+		fontWeight: '600',
+		color: '#374151',
+	},
+	hint: {
+		flex: 1,
+		alignItems: 'center',
+	},
+	hintText: {
+		fontSize: 12,
+		color: '#6b7280',
+		textAlign: 'center',
+	},
+	saveButton: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 4,
+		paddingVertical: 8,
+		paddingHorizontal: 10,
+		borderRadius: 8,
+		backgroundColor: '#2563eb',
+	},
+	saveDisabled: {
+		backgroundColor: '#f3f4f6',
+	},
+	saveLabel: {
+		fontSize: 14,
+		fontWeight: '700',
+		color: '#fff',
+	},
+	saveLabelDisabled: {
+		color: '#9ca3af',
+	},
+});

--- a/src/components/RouteMap.tsx
+++ b/src/components/RouteMap.tsx
@@ -33,6 +33,7 @@ export default function RouteMap() {
 		Location.requestForegroundPermissionsAsync();
 	}, []);
 
+	const editingMode = useRouteStore((s) => s.editingMode);
 	const waypoints = useRouteStore((s) => s.waypoints);
 	const route = useRouteStore((s) => s.route);
 	const isLoading = useRouteStore((s) => s.isLoading);
@@ -56,6 +57,8 @@ export default function RouteMap() {
 	);
 	const [activeStyleId, setActiveStyleId] = useState<MapStyleId>('outdoors');
 	const [layerMenuOpen, setLayerMenuOpen] = useState(false);
+
+	const isCreating = editingMode === 'creating';
 
 	const activeStyle =
 		MAP_STYLES.find((s) => s.id === activeStyleId) ?? MAP_STYLES[0];
@@ -124,11 +127,12 @@ export default function RouteMap() {
 
 	const handleLongPress = useCallback(
 		(feature: Feature<Geometry>) => {
+			if (!isCreating) return;
 			const point = feature as Feature<Point>;
 			const [longitude, latitude] = point.geometry.coordinates;
 			addWaypoint({ longitude, latitude });
 		},
-		[addWaypoint],
+		[addWaypoint, isCreating],
 	);
 
 	return (
@@ -153,52 +157,54 @@ export default function RouteMap() {
 
 				<RoutePolyline />
 
-				{waypoints.map((wp, index) => (
-					<WaypointMarker
-						key={wp.id}
-						waypoint={wp}
-						index={index}
-						total={waypoints.length}
-						onDragMove={(coord) => {
-							const neighbors: Coordinate[] = [];
-							if (index > 0) neighbors.push(waypoints[index - 1].coordinate);
-							if (index < waypoints.length - 1)
-								neighbors.push(waypoints[index + 1].coordinate);
-							setDragPreview(coord, neighbors);
-							setDraggingIndices([index]);
-						}}
-						onDragFinish={() => {
-							clearDragPreview();
-							clearDraggingIndices();
-							const pending: number[] = [];
-							if (index > 0) pending.push(index - 1);
-							if (index < waypoints.length - 1) pending.push(index);
-							setPendingDragSegments(pending);
-						}}
-					/>
-				))}
-
-				{segmentMidpoints.map((midCoord, index) => {
-					const wp = waypoints[index];
-					const next = waypoints[index + 1];
-					return (
-						<MidpointMarker
-							key={`mid-${wp.id}-${next.id}`}
-							id={`mid-${wp.id}-${next.id}`}
-							coordinate={midCoord}
-							afterIndex={index}
+				{isCreating &&
+					waypoints.map((wp, index) => (
+						<WaypointMarker
+							key={wp.id}
+							waypoint={wp}
+							index={index}
+							total={waypoints.length}
 							onDragMove={(coord) => {
-								setDragPreview(coord, [wp.coordinate, next.coordinate]);
-								setDraggingIndices([index, index + 1]);
+								const neighbors: Coordinate[] = [];
+								if (index > 0) neighbors.push(waypoints[index - 1].coordinate);
+								if (index < waypoints.length - 1)
+									neighbors.push(waypoints[index + 1].coordinate);
+								setDragPreview(coord, neighbors);
+								setDraggingIndices([index]);
 							}}
 							onDragFinish={() => {
 								clearDragPreview();
 								clearDraggingIndices();
-								setPendingDragSegments([index]);
+								const pending: number[] = [];
+								if (index > 0) pending.push(index - 1);
+								if (index < waypoints.length - 1) pending.push(index);
+								setPendingDragSegments(pending);
 							}}
 						/>
-					);
-				})}
+					))}
+
+				{isCreating &&
+					segmentMidpoints.map((midCoord, index) => {
+						const wp = waypoints[index];
+						const next = waypoints[index + 1];
+						return (
+							<MidpointMarker
+								key={`mid-${wp.id}-${next.id}`}
+								id={`mid-${wp.id}-${next.id}`}
+								coordinate={midCoord}
+								afterIndex={index}
+								onDragMove={(coord) => {
+									setDragPreview(coord, [wp.coordinate, next.coordinate]);
+									setDraggingIndices([index, index + 1]);
+								}}
+								onDragFinish={() => {
+									clearDragPreview();
+									clearDraggingIndices();
+									setPendingDragSegments([index]);
+								}}
+							/>
+						);
+					})}
 			</MapLibreGL.MapView>
 
 			{isLoading && (
@@ -245,20 +251,24 @@ export default function RouteMap() {
 				<TouchableOpacity style={styles.layerButton} onPress={handleLocateMe}>
 					<Locate size={20} color={userLocation ? '#374151' : '#9ca3af'} />
 				</TouchableOpacity>
-				<TouchableOpacity
-					style={styles.layerButton}
-					onPress={undoLastWaypoint}
-					disabled={!hasWaypoints}
-				>
-					<Undo2 size={20} color={hasWaypoints ? '#374151' : '#9ca3af'} />
-				</TouchableOpacity>
-				<TouchableOpacity
-					style={styles.layerButton}
-					onPress={handleClearAll}
-					disabled={!hasWaypoints}
-				>
-					<Trash2 size={20} color={hasWaypoints ? '#dc2626' : '#9ca3af'} />
-				</TouchableOpacity>
+				{isCreating && (
+					<>
+						<TouchableOpacity
+							style={styles.layerButton}
+							onPress={undoLastWaypoint}
+							disabled={!hasWaypoints}
+						>
+							<Undo2 size={20} color={hasWaypoints ? '#374151' : '#9ca3af'} />
+						</TouchableOpacity>
+						<TouchableOpacity
+							style={styles.layerButton}
+							onPress={handleClearAll}
+							disabled={!hasWaypoints}
+						>
+							<Trash2 size={20} color={hasWaypoints ? '#dc2626' : '#9ca3af'} />
+						</TouchableOpacity>
+					</>
+				)}
 			</View>
 
 			<ControlsPanel mapViewRef={mapViewRef} />

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -1,0 +1,79 @@
+import * as SQLite from 'expo-sqlite';
+import type { Feature, LineString } from 'geojson';
+import type { RouteStats, Waypoint } from '../store/routeStore';
+
+export interface SavedRoute {
+	id: number;
+	name: string;
+	waypoints: Waypoint[];
+	geometry: Feature<LineString>;
+	stats: RouteStats | null;
+	createdAt: string;
+}
+
+let _db: SQLite.SQLiteDatabase | null = null;
+
+function getDb(): SQLite.SQLiteDatabase {
+	if (!_db) {
+		_db = SQLite.openDatabaseSync('routes.db');
+	}
+	return _db;
+}
+
+export function initDb(): void {
+	const db = getDb();
+	db.execSync(
+		`CREATE TABLE IF NOT EXISTS routes (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			name TEXT NOT NULL,
+			waypoints TEXT NOT NULL,
+			geometry TEXT NOT NULL,
+			stats TEXT,
+			created_at TEXT NOT NULL
+		);`,
+	);
+}
+
+export function saveRoute(
+	name: string,
+	waypoints: Waypoint[],
+	geometry: Feature<LineString>,
+	stats: RouteStats | null,
+): number {
+	const db = getDb();
+	const result = db.runSync(
+		'INSERT INTO routes (name, waypoints, geometry, stats, created_at) VALUES (?, ?, ?, ?, ?)',
+		name,
+		JSON.stringify(waypoints),
+		JSON.stringify(geometry),
+		stats ? JSON.stringify(stats) : null,
+		new Date().toISOString(),
+	);
+	return result.lastInsertRowId;
+}
+
+export function listRoutes(): SavedRoute[] {
+	const db = getDb();
+	const rows = db.getAllSync<{
+		id: number;
+		name: string;
+		waypoints: string;
+		geometry: string;
+		stats: string | null;
+		created_at: string;
+	}>('SELECT * FROM routes ORDER BY created_at DESC');
+
+	return rows.map((row) => ({
+		id: row.id,
+		name: row.name,
+		waypoints: JSON.parse(row.waypoints) as Waypoint[],
+		geometry: JSON.parse(row.geometry) as Feature<LineString>,
+		stats: row.stats ? (JSON.parse(row.stats) as RouteStats) : null,
+		createdAt: row.created_at,
+	}));
+}
+
+export function deleteRoute(id: number): void {
+	const db = getDb();
+	db.runSync('DELETE FROM routes WHERE id = ?', id);
+}

--- a/src/store/routeStore.ts
+++ b/src/store/routeStore.ts
@@ -17,7 +17,11 @@ export interface RouteStats {
 	lossM: number;
 }
 
+/** 'view' = read-only, no editing; 'creating' = user is building a new route */
+export type EditingMode = 'view' | 'creating';
+
 interface RouteState {
+	editingMode: EditingMode;
 	waypoints: Waypoint[];
 	route: Feature<LineString> | null;
 	/** [distanceKm, elevationM] pairs for the elevation profile chart */
@@ -40,6 +44,7 @@ interface RouteState {
 }
 
 interface RouteActions {
+	setEditingMode: (mode: EditingMode) => void;
 	addWaypoint: (coord: Coordinate) => void;
 	insertWaypoint: (afterIndex: number, coord: Coordinate) => void;
 	moveWaypoint: (id: string, coord: Coordinate) => void;
@@ -51,6 +56,8 @@ interface RouteActions {
 	setIsSnapping: (value: boolean) => void;
 	setIsLoading: (value: boolean) => void;
 	setFocusCoordinate: (coord: [number, number] | null) => void;
+	/** Clears only the active editing state (waypoints, route, elevation, stats).
+	 *  Does NOT affect persisted saved routes in the database. */
 	clearAll: () => void;
 	/** Load an array of coordinates as waypoints (e.g. from GPX import) */
 	loadWaypoints: (coords: Coordinate[]) => void;
@@ -70,6 +77,7 @@ function makeId(): string {
 }
 
 export const useRouteStore = create<RouteState & RouteActions>((set) => ({
+	editingMode: 'view',
 	waypoints: [],
 	route: null,
 	elevationData: [],
@@ -81,6 +89,8 @@ export const useRouteStore = create<RouteState & RouteActions>((set) => ({
 	pendingDragSegments: [],
 	dragPreviewCoord: null,
 	dragPreviewNeighbors: [],
+
+	setEditingMode: (editingMode) => set({ editingMode }),
 
 	addWaypoint: (coord) =>
 		set((state) => ({


### PR DESCRIPTION
Implements a view/creating mode system (issue #15) and SQLite route
persistence via expo-sqlite (issue #16):

- routeStore: add editingMode ('view' | 'creating') and setEditingMode
- RouteMap: gate long-press, waypoint markers, midpoint markers, undo
  and clear controls behind 'creating' mode
- AddRouteButton: CTA shown in view mode to enter creation mode
- RouteActionBar: Save/Cancel bar shown in creating mode; Save is
  enabled only when ≥2 waypoints + computed route exist; Cancel shows
  a confirmation dialog if waypoints are present
- NameRouteModal: platform-safe Android TextInput modal for naming a
  route before saving
- db.ts: SQLite service (initDb, saveRoute, listRoutes, deleteRoute)
  using expo-sqlite synchronous API; clearAll leaves persisted rows
  untouched
- ControlsPanel: mode-aware UI — view mode shows saved routes list and
  AddRouteButton; creating mode shows RouteActionBar, elevation profile
  and inline hint

https://claude.ai/code/session_01F4kuEpYBzfDXUsh81LUJkc