### PR TITLE
feat: show list of saved routes; tap to view on map (#17)

### DIFF
--- a/src/components/RouteListModal.tsx
+++ b/src/components/RouteListModal.tsx
@@ -1,0 +1,237 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { X } from 'lucide-react-native';
+import { useCallback, useRef, useState } from 'react';
+import {
+	ActivityIndicator,
+	Alert,
+	FlatList,
+	Modal,
+	Pressable,
+	StyleSheet,
+	Text,
+	TouchableOpacity,
+	View,
+} from 'react-native';
+import { deleteRoute } from '../services/db';
+import { useRouteStore } from '../store/routeStore';
+import { useRoutes } from '../hooks/useRoutes';
+
+interface Props {
+	open: boolean;
+	onClose: () => void;
+}
+
+function formatDate(iso: string): string {
+	const d = new Date(iso);
+	return d.toLocaleDateString(undefined, {
+		year: 'numeric',
+		month: 'short',
+		day: 'numeric',
+	});
+}
+
+function formatDistance(km: number): string {
+	return km >= 1 ? `${km.toFixed(1)} km` : `${Math.round(km * 1000)} m`;
+}
+
+export default function RouteListModal({ open, onClose }: Props) {
+	const queryClient = useQueryClient();
+	const loadRouteForViewing = useRouteStore((s) => s.loadRouteForViewing);
+	const { data: routes, isLoading } = useRoutes();
+
+	const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	const [pressedId, setPressedId] = useState<number | null>(null);
+
+	const handleSelect = useCallback(
+		(id: number) => {
+			loadRouteForViewing(id);
+			onClose();
+		},
+		[loadRouteForViewing, onClose],
+	);
+
+	const confirmDelete = useCallback(
+		(id: number, name: string) => {
+			Alert.alert('Delete route', `Delete "${name}"? This cannot be undone.`, [
+				{ text: 'Cancel', style: 'cancel' },
+				{
+					text: 'Delete',
+					style: 'destructive',
+					onPress: () => {
+						deleteRoute(id);
+						queryClient.invalidateQueries({ queryKey: ['savedRoutes'] });
+					},
+				},
+			]);
+		},
+		[queryClient],
+	);
+
+	return (
+		<Modal
+			visible={open}
+			animationType="slide"
+			presentationStyle="pageSheet"
+			onRequestClose={onClose}
+		>
+			<View style={styles.container}>
+				<View style={styles.header}>
+					<Text style={styles.title}>Saved Routes</Text>
+					<TouchableOpacity style={styles.closeButton} onPress={onClose}>
+						<X size={20} color="#374151" />
+					</TouchableOpacity>
+				</View>
+
+				{isLoading ? (
+					<View style={styles.centered}>
+						<ActivityIndicator size="large" color="#3b82f6" />
+					</View>
+				) : !routes || routes.length === 0 ? (
+					<View style={styles.centered}>
+						<Text style={styles.emptyText}>No saved routes yet.</Text>
+						<Text style={styles.emptySubText}>
+							Tap Add Route to start.
+						</Text>
+					</View>
+				) : (
+					<FlatList
+						data={routes}
+						keyExtractor={(item) => String(item.id)}
+						contentContainerStyle={styles.list}
+						renderItem={({ item }) => (
+							<Pressable
+								style={[
+									styles.item,
+									pressedId === item.id && styles.itemPressed,
+								]}
+								onPress={() => handleSelect(item.id)}
+								onLongPress={() => {
+									setPressedId(item.id);
+									confirmDelete(item.id, item.name);
+									setPressedId(null);
+								}}
+								delayLongPress={500}
+							>
+								<View style={styles.itemMain}>
+									<Text style={styles.itemName} numberOfLines={1}>
+										{item.name}
+									</Text>
+									<Text style={styles.itemDate}>{formatDate(item.createdAt)}</Text>
+								</View>
+								{item.stats && (
+									<View style={styles.itemStats}>
+										<Text style={styles.statText}>
+											{formatDistance(item.stats.distanceKm)}
+										</Text>
+										<Text style={styles.statDivider}>·</Text>
+										<Text style={styles.statText}>
+											↑ {Math.round(item.stats.gainM)} m
+										</Text>
+									</View>
+								)}
+							</Pressable>
+						)}
+						ItemSeparatorComponent={() => <View style={styles.separator} />}
+					/>
+				)}
+			</View>
+		</Modal>
+	);
+}
+
+const styles = StyleSheet.create({
+	container: {
+		flex: 1,
+		backgroundColor: '#f9fafb',
+	},
+	header: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		paddingHorizontal: 16,
+		paddingTop: 20,
+		paddingBottom: 12,
+		backgroundColor: '#fff',
+		borderBottomWidth: StyleSheet.hairlineWidth,
+		borderBottomColor: '#e5e7eb',
+	},
+	title: {
+		fontSize: 18,
+		fontWeight: '600',
+		color: '#111827',
+	},
+	closeButton: {
+		width: 36,
+		height: 36,
+		borderRadius: 18,
+		backgroundColor: '#f3f4f6',
+		alignItems: 'center',
+		justifyContent: 'center',
+	},
+	centered: {
+		flex: 1,
+		alignItems: 'center',
+		justifyContent: 'center',
+		padding: 32,
+	},
+	emptyText: {
+		fontSize: 16,
+		fontWeight: '600',
+		color: '#374151',
+		marginBottom: 4,
+	},
+	emptySubText: {
+		fontSize: 14,
+		color: '#6b7280',
+		textAlign: 'center',
+	},
+	list: {
+		padding: 12,
+	},
+	item: {
+		backgroundColor: '#fff',
+		borderRadius: 10,
+		padding: 14,
+		shadowColor: '#000',
+		shadowOffset: { width: 0, height: 1 },
+		shadowOpacity: 0.06,
+		shadowRadius: 2,
+		elevation: 2,
+	},
+	itemPressed: {
+		opacity: 0.75,
+	},
+	itemMain: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		marginBottom: 4,
+	},
+	itemName: {
+		fontSize: 15,
+		fontWeight: '600',
+		color: '#111827',
+		flex: 1,
+		marginRight: 8,
+	},
+	itemDate: {
+		fontSize: 12,
+		color: '#9ca3af',
+	},
+	itemStats: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		gap: 6,
+	},
+	statText: {
+		fontSize: 13,
+		color: '#6b7280',
+	},
+	statDivider: {
+		fontSize: 13,
+		color: '#d1d5db',
+	},
+	separator: {
+		height: 8,
+	},
+});

--- a/src/components/RouteMap.tsx
+++ b/src/components/RouteMap.tsx
@@ -4,7 +4,7 @@ import MapLibreGL, {
 } from '@maplibre/maplibre-react-native';
 import * as Location from 'expo-location';
 import type { Feature, Geometry, Point } from 'geojson';
-import { Layers2, Locate, Trash2, Undo2 } from 'lucide-react-native';
+import { Layers2, List, Locate, Trash2, Undo2 } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
 	ActivityIndicator,
@@ -21,6 +21,7 @@ import { type Coordinate, useRouteStore } from '../store/routeStore';
 import { computeSegmentMidpoints } from '../utils/routeMidpoint';
 import ControlsPanel from './ControlsPanel';
 import MidpointMarker from './MidpointMarker';
+import RouteListModal from './RouteListModal';
 import RoutePolyline from './RoutePolyline';
 import WaypointMarker from './WaypointMarker';
 
@@ -57,6 +58,7 @@ export default function RouteMap() {
 	);
 	const [activeStyleId, setActiveStyleId] = useState<MapStyleId>('outdoors');
 	const [layerMenuOpen, setLayerMenuOpen] = useState(false);
+	const [routeListOpen, setRouteListOpen] = useState(false);
 
 	const isCreating = editingMode === 'creating';
 
@@ -251,6 +253,12 @@ export default function RouteMap() {
 				<TouchableOpacity style={styles.layerButton} onPress={handleLocateMe}>
 					<Locate size={20} color={userLocation ? '#374151' : '#9ca3af'} />
 				</TouchableOpacity>
+				<TouchableOpacity
+					style={styles.layerButton}
+					onPress={() => setRouteListOpen(true)}
+				>
+					<List size={20} color="#374151" />
+				</TouchableOpacity>
 				{isCreating && (
 					<>
 						<TouchableOpacity
@@ -272,6 +280,11 @@ export default function RouteMap() {
 			</View>
 
 			<ControlsPanel mapViewRef={mapViewRef} />
+
+		<RouteListModal
+			open={routeListOpen}
+			onClose={() => setRouteListOpen(false)}
+		/>
 		</View>
 	);
 }

--- a/src/hooks/useRoutes.ts
+++ b/src/hooks/useRoutes.ts
@@ -1,0 +1,26 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { AppState } from 'react-native';
+import { listRoutes } from '../services/db';
+
+/**
+ * Fetches all saved routes from the local SQLite database.
+ * Automatically refetches when the app returns to the foreground.
+ */
+export function useRoutes() {
+	const queryClient = useQueryClient();
+
+	useEffect(() => {
+		const sub = AppState.addEventListener('change', (state) => {
+			if (state === 'active') {
+				queryClient.invalidateQueries({ queryKey: ['savedRoutes'] });
+			}
+		});
+		return () => sub.remove();
+	}, [queryClient]);
+
+	return useQuery({
+		queryKey: ['savedRoutes'],
+		queryFn: listRoutes,
+	});
+}

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -73,6 +73,27 @@ export function listRoutes(): SavedRoute[] {
 	}));
 }
 
+export function getRoute(id: number): SavedRoute | null {
+	const db = getDb();
+	const row = db.getFirstSync<{
+		id: number;
+		name: string;
+		waypoints: string;
+		geometry: string;
+		stats: string | null;
+		created_at: string;
+	}>('SELECT * FROM routes WHERE id = ?', id);
+	if (!row) return null;
+	return {
+		id: row.id,
+		name: row.name,
+		waypoints: JSON.parse(row.waypoints) as Waypoint[],
+		geometry: JSON.parse(row.geometry) as Feature<LineString>,
+		stats: row.stats ? (JSON.parse(row.stats) as RouteStats) : null,
+		createdAt: row.created_at,
+	};
+}
+
 export function deleteRoute(id: number): void {
 	const db = getDb();
 	db.runSync('DELETE FROM routes WHERE id = ?', id);

--- a/src/store/routeStore.ts
+++ b/src/store/routeStore.ts
@@ -1,5 +1,6 @@
 import type { Feature, LineString } from 'geojson';
 import { create } from 'zustand';
+import { getRoute } from '../services/db';
 
 export interface Coordinate {
 	longitude: number;
@@ -33,6 +34,8 @@ interface RouteState {
 	isLoading: boolean;
 	/** Set by ElevationProfile on tap; watched by RouteMap to fly camera */
 	focusCoordinate: [number, number] | null;
+	/** ID of the route currently loaded in view mode; null when creating or empty */
+	activeRouteId: number | null;
 	/** Indices of waypoints currently being dragged; adjacent route segments are suppressed */
 	draggingWaypointIndices: number[];
 	/** Segment indices that render as dotted straight lines after drag ends, until route resolves */
@@ -61,6 +64,8 @@ interface RouteActions {
 	clearAll: () => void;
 	/** Load an array of coordinates as waypoints (e.g. from GPX import) */
 	loadWaypoints: (coords: Coordinate[]) => void;
+	/** Load a saved route by id into view (read-only) mode */
+	loadRouteForViewing: (id: number) => void;
 	setDraggingIndices: (indices: number[]) => void;
 	clearDraggingIndices: () => void;
 	setPendingDragSegments: (indices: number[]) => void;
@@ -85,6 +90,7 @@ export const useRouteStore = create<RouteState & RouteActions>((set) => ({
 	isSnapping: true,
 	isLoading: false,
 	focusCoordinate: null,
+	activeRouteId: null,
 	draggingWaypointIndices: [],
 	pendingDragSegments: [],
 	dragPreviewCoord: null,
@@ -135,6 +141,7 @@ export const useRouteStore = create<RouteState & RouteActions>((set) => ({
 			elevationData: [],
 			routeStats: null,
 			focusCoordinate: null,
+			activeRouteId: null,
 		}),
 
 	loadWaypoints: (coords) =>
@@ -144,6 +151,20 @@ export const useRouteStore = create<RouteState & RouteActions>((set) => ({
 			elevationData: [],
 			routeStats: null,
 		}),
+
+	loadRouteForViewing: (id) => {
+		const saved = getRoute(id);
+		if (!saved) return;
+		set({
+			activeRouteId: id,
+			editingMode: 'view',
+			waypoints: saved.waypoints,
+			route: saved.geometry,
+			routeStats: saved.stats,
+			elevationData: [],
+			focusCoordinate: null,
+		});
+	},
 
 	setDraggingIndices: (draggingWaypointIndices) =>
 		set({ draggingWaypointIndices }),


### PR DESCRIPTION
- Add getRoute(id) to db.ts for single-route lookup
- Add activeRouteId + loadRouteForViewing(id) action to routeStore
- New useRoutes hook: TanStack Query with AppState refetch-on-focus
- New RouteListModal: FlatList with name/distance/gain/date, empty state, ActivityIndicator, tap to load in view mode, long-press to confirm delete
- RouteMap: List icon button (always visible) opens RouteListModal

https://claude.ai/code/session_01Ugvkg2abfTLwnmQEApXdAd