### PR TITLE
feat: add Supabase cloud backup and sync for saved routes (#18)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
 # Get a free API key at https://stadiamaps.com/ (200k tile requests/month free)
 # Used for both map tiles and Valhalla routing
 EXPO_PUBLIC_STADIA_KEY=your_stadia_api_key_here
+
+# Supabase — cloud backup & sync (issue #18)
+# Find these in your Supabase project Settings → API
+EXPO_PUBLIC_SUPABASE_URL=https://your-project-ref.supabase.co
+EXPO_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anon_key_here

--- a/App.tsx
+++ b/App.tsx
@@ -1,10 +1,13 @@
 import MapLibreGL from '@maplibre/maplibre-react-native';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { StatusBar } from 'expo-status-bar';
+import { useEffect } from 'react';
 import { StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import RouteMap from './src/components/RouteMap';
+import { getSession, onAuthStateChange } from './src/services/authService';
+import { useAuthStore } from './src/store/authStore';
 
 // MapLibre forked from Mapbox SDK — must explicitly clear the token
 // so the native layer doesn't block tile requests waiting for Mapbox auth.
@@ -19,12 +22,34 @@ const queryClient = new QueryClient({
 	},
 });
 
+function AuthBootstrap() {
+	const setSession = useAuthStore((s) => s.setSession);
+	const setLoading = useAuthStore((s) => s.setLoading);
+
+	useEffect(() => {
+		// Restore persisted session on cold start
+		getSession().then((session) => {
+			setSession(session);
+			setLoading(false);
+		});
+
+		// Keep store in sync with Supabase auth events
+		const unsubscribe = onAuthStateChange((session) => {
+			setSession(session);
+		});
+		return unsubscribe;
+	}, [setSession, setLoading]);
+
+	return null;
+}
+
 export default function App() {
 	return (
 		<QueryClientProvider client={queryClient}>
 			<GestureHandlerRootView style={styles.root}>
 				<SafeAreaProvider>
 					<StatusBar style="dark" />
+					<AuthBootstrap />
 					<RouteMap />
 				</SafeAreaProvider>
 			</GestureHandlerRootView>

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	},
 	"dependencies": {
 		"@gorhom/bottom-sheet": "^4.6.4",
+		"@supabase/supabase-js": "^2.49.4",
 		"@maplibre/maplibre-react-native": "^10.0.0",
 		"@tanstack/react-query": "^5.95.0",
 		"expo": "~52.0.0",
@@ -24,6 +25,7 @@
 		"expo-keep-awake": "~14.0.3",
 		"expo-location": "~18.0.10",
 		"expo-sharing": "~13.0.0",
+		"expo-secure-store": "~14.0.0",
 		"expo-sqlite": "^55.0.11",
 		"expo-status-bar": "~2.0.1",
 		"fast-xml-parser": "^4.4.0",

--- a/src/components/AccountModal.tsx
+++ b/src/components/AccountModal.tsx
@@ -1,0 +1,222 @@
+import { useState } from 'react';
+import {
+	ActivityIndicator,
+	Alert,
+	KeyboardAvoidingView,
+	Modal,
+	Platform,
+	StyleSheet,
+	Text,
+	TextInput,
+	TouchableOpacity,
+	View,
+} from 'react-native';
+import { signIn, signOut } from '../services/authService';
+import { pullMissingRoutes } from '../services/syncService';
+import { useAuthStore } from '../store/authStore';
+
+interface Props {
+	visible: boolean;
+	onClose: () => void;
+	/** Called after a successful sign-in so the route list can refresh */
+	onSyncComplete?: () => void;
+}
+
+export default function AccountModal({
+	visible,
+	onClose,
+	onSyncComplete,
+}: Props) {
+	const user = useAuthStore((s) => s.user);
+
+	const [email, setEmail] = useState('');
+	const [password, setPassword] = useState('');
+	const [isBusy, setIsBusy] = useState(false);
+
+	const handleSignIn = async () => {
+		if (!email.trim() || !password) {
+			Alert.alert('Missing fields', 'Please enter your email and password.');
+			return;
+		}
+		setIsBusy(true);
+		try {
+			const result = await signIn(email.trim(), password);
+			if (result.error) {
+				Alert.alert('Sign-in failed', result.error);
+				return;
+			}
+			// Pull any missing remote routes in the background
+			pullMissingRoutes()
+				.then(() => onSyncComplete?.())
+				.catch(() => {}); // silent
+			onClose();
+		} finally {
+			setIsBusy(false);
+		}
+	};
+
+	const handleSignOut = async () => {
+		setIsBusy(true);
+		try {
+			await signOut();
+			onClose();
+		} finally {
+			setIsBusy(false);
+		}
+	};
+
+	return (
+		<Modal
+			visible={visible}
+			animationType="slide"
+			transparent
+			onRequestClose={onClose}
+		>
+			<KeyboardAvoidingView
+				style={styles.overlay}
+				behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+			>
+				<View style={styles.sheet}>
+					<Text style={styles.title}>Account</Text>
+
+					{user ? (
+						// ── Signed-in state ──────────────────────────────────────
+						<>
+							<Text style={styles.emailLabel}>Signed in as</Text>
+							<Text style={styles.email}>{user.email}</Text>
+							<Text style={styles.hint}>
+								Routes are backed up automatically when you save them.
+							</Text>
+							<TouchableOpacity
+								style={[styles.button, styles.destructive]}
+								onPress={handleSignOut}
+								disabled={isBusy}
+							>
+								{isBusy ? (
+									<ActivityIndicator color="#fff" />
+								) : (
+									<Text style={styles.buttonText}>Sign out</Text>
+								)}
+							</TouchableOpacity>
+						</>
+					) : (
+						// ── Signed-out state ─────────────────────────────────────
+						<>
+							<Text style={styles.hint}>
+								Sign in to back up your routes to the cloud and sync across
+								devices.
+							</Text>
+							<TextInput
+								style={styles.input}
+								placeholder="Email"
+								placeholderTextColor="#9ca3af"
+								autoCapitalize="none"
+								keyboardType="email-address"
+								value={email}
+								onChangeText={setEmail}
+								editable={!isBusy}
+							/>
+							<TextInput
+								style={styles.input}
+								placeholder="Password"
+								placeholderTextColor="#9ca3af"
+								secureTextEntry
+								value={password}
+								onChangeText={setPassword}
+								editable={!isBusy}
+							/>
+							<TouchableOpacity
+								style={styles.button}
+								onPress={handleSignIn}
+								disabled={isBusy}
+							>
+								{isBusy ? (
+									<ActivityIndicator color="#fff" />
+								) : (
+									<Text style={styles.buttonText}>Sign in</Text>
+								)}
+							</TouchableOpacity>
+						</>
+					)}
+
+					<TouchableOpacity
+						style={styles.cancelButton}
+						onPress={onClose}
+						disabled={isBusy}
+					>
+						<Text style={styles.cancelText}>Cancel</Text>
+					</TouchableOpacity>
+				</View>
+			</KeyboardAvoidingView>
+		</Modal>
+	);
+}
+
+const styles = StyleSheet.create({
+	overlay: {
+		flex: 1,
+		justifyContent: 'flex-end',
+		backgroundColor: 'rgba(0,0,0,0.4)',
+	},
+	sheet: {
+		backgroundColor: '#fff',
+		borderTopLeftRadius: 20,
+		borderTopRightRadius: 20,
+		padding: 24,
+		gap: 12,
+	},
+	title: {
+		fontSize: 18,
+		fontWeight: '700',
+		color: '#111827',
+		marginBottom: 4,
+	},
+	emailLabel: {
+		fontSize: 12,
+		color: '#6b7280',
+		textTransform: 'uppercase',
+		letterSpacing: 0.5,
+	},
+	email: {
+		fontSize: 15,
+		fontWeight: '600',
+		color: '#111827',
+	},
+	hint: {
+		fontSize: 13,
+		color: '#6b7280',
+		lineHeight: 18,
+	},
+	input: {
+		borderWidth: 1,
+		borderColor: '#d1d5db',
+		borderRadius: 8,
+		paddingHorizontal: 12,
+		paddingVertical: 10,
+		fontSize: 15,
+		color: '#111827',
+	},
+	button: {
+		backgroundColor: '#2563eb',
+		borderRadius: 8,
+		paddingVertical: 12,
+		alignItems: 'center',
+		marginTop: 4,
+	},
+	destructive: {
+		backgroundColor: '#dc2626',
+	},
+	buttonText: {
+		color: '#fff',
+		fontWeight: '600',
+		fontSize: 15,
+	},
+	cancelButton: {
+		alignItems: 'center',
+		paddingVertical: 8,
+	},
+	cancelText: {
+		fontSize: 14,
+		color: '#6b7280',
+	},
+});

--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -27,7 +27,10 @@ import {
 } from '../services/db';
 import { exportGpx } from '../services/gpxExport';
 import { parseGpx } from '../services/gpxParser';
+import { deleteRouteInCloud } from '../services/syncService';
+import { useAuthStore } from '../store/authStore';
 import { useRouteStore } from '../store/routeStore';
+import AccountModal from './AccountModal';
 import AddRouteButton from './AddRouteButton';
 import ElevationProfile from './ElevationProfile';
 import RouteActionBar from './RouteActionBar';
@@ -51,10 +54,13 @@ export default function ControlsPanel({ mapViewRef }: Props) {
 
 	const isCreating = editingMode === 'creating';
 
+	const authUser = useAuthStore((s) => s.user);
+
 	const [savedRoutes, setSavedRoutes] = useState<SavedRoute[]>([]);
 	const [offlineProgress, setOfflineProgress] = useState<number | null>(null);
 	const [isExporting, setIsExporting] = useState(false);
 	const [isImporting, setIsImporting] = useState(false);
+	const [showAccount, setShowAccount] = useState(false);
 
 	// Initialise DB and load saved routes on mount
 	useEffect(() => {
@@ -186,8 +192,12 @@ export default function ControlsPanel({ mapViewRef }: Props) {
 				text: 'Delete',
 				style: 'destructive',
 				onPress: () => {
-					deleteRoute(id);
+					const remoteId = deleteRoute(id);
 					setSavedRoutes(listRoutes());
+					if (remoteId) {
+						// fire-and-forget cloud soft-delete
+						deleteRouteInCloud(remoteId).catch(() => {});
+					}
 				},
 			},
 		]);
@@ -308,8 +318,24 @@ export default function ControlsPanel({ mapViewRef }: Props) {
 							<Text style={styles.downloadText}>⬇ Download Visible Area</Text>
 						)}
 					</TouchableOpacity>
+
+					{/* Cloud account */}
+					<TouchableOpacity
+						style={styles.accountButton}
+						onPress={() => setShowAccount(true)}
+					>
+						<Text style={styles.accountButtonText}>
+							{authUser ? `☁ ${authUser.email}` : '☁ Sign in to back up routes'}
+						</Text>
+					</TouchableOpacity>
 				</View>
 			</BottomSheetScrollView>
+
+			<AccountModal
+				visible={showAccount}
+				onClose={() => setShowAccount(false)}
+				onSyncComplete={refreshRoutes}
+			/>
 		</BottomSheet>
 	);
 }
@@ -486,5 +512,16 @@ const styles = StyleSheet.create({
 		flexDirection: 'row',
 		gap: 8,
 		alignItems: 'center',
+	},
+	accountButton: {
+		paddingVertical: 10,
+		borderRadius: 8,
+		backgroundColor: '#f3f4f6',
+		alignItems: 'center',
+	},
+	accountButtonText: {
+		fontSize: 13,
+		fontWeight: '500',
+		color: '#374151',
 	},
 });

--- a/src/components/RouteActionBar.tsx
+++ b/src/components/RouteActionBar.tsx
@@ -2,6 +2,7 @@ import { Check, X } from 'lucide-react-native';
 import { useCallback, useState } from 'react';
 import { Alert, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { saveRoute } from '../services/db';
+import { pushRoute } from '../services/syncService';
 import { useRouteStore } from '../store/routeStore';
 import NameRouteModal from './NameRouteModal';
 
@@ -28,8 +29,9 @@ export default function RouteActionBar({ onRouteSaved }: Props) {
 	const handleNameConfirm = useCallback(
 		(name: string) => {
 			if (!route) return;
+			let localId: number;
 			try {
-				saveRoute(name, waypoints, route, routeStats);
+				localId = saveRoute(name, waypoints, route, routeStats);
 			} catch (err: unknown) {
 				Alert.alert(
 					'Save failed',
@@ -37,6 +39,8 @@ export default function RouteActionBar({ onRouteSaved }: Props) {
 				);
 				return;
 			}
+			// fire-and-forget background sync
+			pushRoute(localId).catch(() => {});
 			setNamingVisible(false);
 			clearAll();
 			setEditingMode('view');

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,0 +1,45 @@
+import type { Session, User } from '@supabase/supabase-js';
+import { supabase } from './supabase';
+
+export interface AuthResult {
+	user: User | null;
+	session: Session | null;
+	error: string | null;
+}
+
+/** Sign in with email + password. Session is auto-persisted via SecureStore. */
+export async function signIn(
+	email: string,
+	password: string,
+): Promise<AuthResult> {
+	const { data, error } = await supabase.auth.signInWithPassword({
+		email,
+		password,
+	});
+	return {
+		user: data.user,
+		session: data.session,
+		error: error?.message ?? null,
+	};
+}
+
+/** Sign out and clear the persisted session. */
+export async function signOut(): Promise<void> {
+	await supabase.auth.signOut();
+}
+
+/** Restore session from SecureStore (call once on app start). */
+export async function getSession(): Promise<Session | null> {
+	const { data } = await supabase.auth.getSession();
+	return data.session;
+}
+
+/** Subscribe to auth state changes — returns the unsubscribe function. */
+export function onAuthStateChange(
+	callback: (session: Session | null) => void,
+): () => void {
+	const { data } = supabase.auth.onAuthStateChange((_event, session) => {
+		callback(session);
+	});
+	return () => data.subscription.unsubscribe();
+}

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -11,6 +11,18 @@ export interface SavedRoute {
 	createdAt: string;
 }
 
+/** Internal shape used by the sync service — includes cloud-sync fields. */
+export interface RouteForSync {
+	localId: number;
+	remoteId: string | null;
+	name: string;
+	waypoints: Waypoint[];
+	geometry: Feature<LineString>;
+	stats: RouteStats | null;
+	createdAt: string;
+	deletedAt: string | null;
+}
+
 let _db: SQLite.SQLiteDatabase | null = null;
 
 function getDb(): SQLite.SQLiteDatabase {
@@ -22,16 +34,31 @@ function getDb(): SQLite.SQLiteDatabase {
 
 export function initDb(): void {
 	const db = getDb();
+
+	// Original table (kept for backwards compat — new installs get all columns)
 	db.execSync(
 		`CREATE TABLE IF NOT EXISTS routes (
-			id INTEGER PRIMARY KEY AUTOINCREMENT,
-			name TEXT NOT NULL,
-			waypoints TEXT NOT NULL,
-			geometry TEXT NOT NULL,
-			stats TEXT,
-			created_at TEXT NOT NULL
+			id         INTEGER PRIMARY KEY AUTOINCREMENT,
+			name       TEXT    NOT NULL,
+			waypoints  TEXT    NOT NULL,
+			geometry   TEXT    NOT NULL,
+			stats      TEXT,
+			created_at TEXT    NOT NULL
 		);`,
 	);
+
+	// Idempotent column additions for existing installs
+	for (const sql of [
+		'ALTER TABLE routes ADD COLUMN remote_id  TEXT',
+		'ALTER TABLE routes ADD COLUMN deleted_at TEXT',
+		'ALTER TABLE routes ADD COLUMN updated_at TEXT',
+	]) {
+		try {
+			db.execSync(sql);
+		} catch {
+			// Column already exists — safe to ignore
+		}
+	}
 }
 
 export function saveRoute(
@@ -41,13 +68,15 @@ export function saveRoute(
 	stats: RouteStats | null,
 ): number {
 	const db = getDb();
+	const now = new Date().toISOString();
 	const result = db.runSync(
-		'INSERT INTO routes (name, waypoints, geometry, stats, created_at) VALUES (?, ?, ?, ?, ?)',
+		'INSERT INTO routes (name, waypoints, geometry, stats, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
 		name,
 		JSON.stringify(waypoints),
 		JSON.stringify(geometry),
 		stats ? JSON.stringify(stats) : null,
-		new Date().toISOString(),
+		now,
+		now,
 	);
 	return result.lastInsertRowId;
 }
@@ -61,7 +90,7 @@ export function listRoutes(): SavedRoute[] {
 		geometry: string;
 		stats: string | null;
 		created_at: string;
-	}>('SELECT * FROM routes ORDER BY created_at DESC');
+	}>('SELECT * FROM routes WHERE deleted_at IS NULL ORDER BY created_at DESC');
 
 	return rows.map((row) => ({
 		id: row.id,
@@ -82,7 +111,7 @@ export function getRoute(id: number): SavedRoute | null {
 		geometry: string;
 		stats: string | null;
 		created_at: string;
-	}>('SELECT * FROM routes WHERE id = ?', id);
+	}>('SELECT * FROM routes WHERE id = ? AND deleted_at IS NULL', id);
 	if (!row) return null;
 	return {
 		id: row.id,
@@ -94,7 +123,102 @@ export function getRoute(id: number): SavedRoute | null {
 	};
 }
 
-export function deleteRoute(id: number): void {
+/**
+ * Soft-delete: sets `deleted_at` so the route is hidden locally.
+ * Returns the `remote_id` (if any) so the caller can propagate to Supabase.
+ */
+export function deleteRoute(id: number): string | null {
 	const db = getDb();
-	db.runSync('DELETE FROM routes WHERE id = ?', id);
+	const row = db.getFirstSync<{ remote_id: string | null }>(
+		'SELECT remote_id FROM routes WHERE id = ?',
+		id,
+	);
+	db.runSync(
+		'UPDATE routes SET deleted_at = ?, updated_at = ? WHERE id = ?',
+		new Date().toISOString(),
+		new Date().toISOString(),
+		id,
+	);
+	return row?.remote_id ?? null;
+}
+
+// ── Sync helpers (used by syncService only) ─────────────────────────────────
+
+/** Return full row data needed for an upsert to Supabase. */
+export function getRouteForSync(localId: number): RouteForSync | null {
+	const db = getDb();
+	const row = db.getFirstSync<{
+		id: number;
+		remote_id: string | null;
+		name: string;
+		waypoints: string;
+		geometry: string;
+		stats: string | null;
+		created_at: string;
+		deleted_at: string | null;
+	}>('SELECT * FROM routes WHERE id = ?', localId);
+	if (!row) return null;
+	return {
+		localId: row.id,
+		remoteId: row.remote_id,
+		name: row.name,
+		waypoints: JSON.parse(row.waypoints) as Waypoint[],
+		geometry: JSON.parse(row.geometry) as Feature<LineString>,
+		stats: row.stats ? (JSON.parse(row.stats) as RouteStats) : null,
+		createdAt: row.created_at,
+		deletedAt: row.deleted_at,
+	};
+}
+
+/** Store the UUID assigned by Supabase after a successful upsert. */
+export function markRouteSynced(localId: number, remoteId: string): void {
+	const db = getDb();
+	db.runSync(
+		'UPDATE routes SET remote_id = ? WHERE id = ?',
+		remoteId,
+		localId,
+	);
+}
+
+/** All remote_ids that already exist locally (for dedup during pull). */
+export function listLocalRemoteIds(): string[] {
+	const db = getDb();
+	const rows = db.getAllSync<{ remote_id: string }>(
+		'SELECT remote_id FROM routes WHERE remote_id IS NOT NULL',
+	);
+	return rows.map((r) => r.remote_id);
+}
+
+/**
+ * Insert a route downloaded from Supabase.
+ * Skips insert if that remote_id is already present.
+ */
+export function insertRemoteRoute(route: {
+	remoteId: string;
+	name: string;
+	waypoints: Waypoint[];
+	geometry: Feature<LineString>;
+	stats: RouteStats | null;
+	createdAt: string;
+}): void {
+	const db = getDb();
+	const existing = db.getFirstSync<{ id: number }>(
+		'SELECT id FROM routes WHERE remote_id = ?',
+		route.remoteId,
+	);
+	if (existing) return; // already synced
+
+	const now = new Date().toISOString();
+	db.runSync(
+		`INSERT INTO routes
+			(name, waypoints, geometry, stats, created_at, updated_at, remote_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		route.name,
+		JSON.stringify(route.waypoints),
+		JSON.stringify(route.geometry),
+		route.stats ? JSON.stringify(route.stats) : null,
+		route.createdAt,
+		now,
+		route.remoteId,
+	);
 }

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -1,0 +1,43 @@
+import { createClient } from '@supabase/supabase-js';
+import * as SecureStore from 'expo-secure-store';
+
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL ?? '';
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY ?? '';
+
+if (__DEV__) {
+	console.log('[supabase] URL configured:', supabaseUrl.length > 0);
+}
+
+/**
+ * SecureStore adapter for @supabase/supabase-js session persistence.
+ * expo-secure-store values are limited to ~2 KB on some devices; the Supabase
+ * session JSON is well under that limit.
+ */
+const secureStoreAdapter = {
+	getItem: (key: string) => SecureStore.getItemAsync(key),
+	setItem: (key: string, value: string) =>
+		SecureStore.setItemAsync(key, value),
+	removeItem: (key: string) => SecureStore.deleteItemAsync(key),
+};
+
+export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+	auth: {
+		storage: secureStoreAdapter,
+		autoRefreshToken: true,
+		persistSession: true,
+		detectSessionInUrl: false,
+	},
+});
+
+/** Row shape returned by the Supabase `routes` table. */
+export interface SupabaseRoute {
+	id: string; // UUID
+	user_id: string;
+	name: string;
+	waypoints: unknown;
+	geometry: unknown;
+	stats: unknown | null;
+	created_at: string;
+	updated_at: string;
+	deleted_at: string | null;
+}

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -1,0 +1,111 @@
+/**
+ * Cloud sync — local-first, fire-and-forget.
+ *
+ * Writes always go to SQLite first. Supabase calls happen in the background;
+ * failures are logged in dev but never surface to the user.
+ */
+import type { Feature, LineString } from 'geojson';
+import type { RouteStats, Waypoint } from '../store/routeStore';
+import {
+	getRouteForSync,
+	insertRemoteRoute,
+	listLocalRemoteIds,
+	markRouteSynced,
+} from './db';
+import { supabase, type SupabaseRoute } from './supabase';
+
+/** Push a single local route to Supabase (upsert). Silent on failure. */
+export async function pushRoute(localId: number): Promise<void> {
+	try {
+		const row = getRouteForSync(localId);
+		if (!row) return;
+
+		const { data: userData } = await supabase.auth.getUser();
+		if (!userData.user) return; // not signed in — skip silently
+
+		const payload = {
+			...(row.remoteId ? { id: row.remoteId } : {}),
+			user_id: userData.user.id,
+			name: row.name,
+			waypoints: row.waypoints,
+			geometry: row.geometry,
+			stats: row.stats,
+			created_at: row.createdAt,
+			deleted_at: row.deletedAt ?? null,
+		};
+
+		const { data, error } = await supabase
+			.from('routes')
+			.upsert(payload, { onConflict: 'id' })
+			.select('id')
+			.single();
+
+		if (error) {
+			if (__DEV__) console.warn('[sync] pushRoute failed:', error.message);
+			return;
+		}
+
+		if (data?.id && data.id !== row.remoteId) {
+			markRouteSynced(localId, data.id as string);
+		}
+	} catch (err) {
+		if (__DEV__) console.warn('[sync] pushRoute exception:', err);
+	}
+}
+
+/** Soft-delete a route in Supabase. Silent on failure. */
+export async function deleteRouteInCloud(remoteId: string): Promise<void> {
+	try {
+		const { error } = await supabase
+			.from('routes')
+			.update({ deleted_at: new Date().toISOString() })
+			.eq('id', remoteId);
+
+		if (error && __DEV__) {
+			console.warn('[sync] deleteRouteInCloud failed:', error.message);
+		}
+	} catch (err) {
+		if (__DEV__) console.warn('[sync] deleteRouteInCloud exception:', err);
+	}
+}
+
+/**
+ * Download routes from Supabase that are missing locally and insert them.
+ * Called once after a successful sign-in.
+ */
+export async function pullMissingRoutes(): Promise<void> {
+	try {
+		const { data: userData } = await supabase.auth.getUser();
+		if (!userData.user) return;
+
+		// Fetch all non-deleted remote routes for this user
+		const { data: remoteRoutes, error } = await supabase
+			.from('routes')
+			.select('*')
+			.is('deleted_at', null)
+			.returns<SupabaseRoute[]>();
+
+		if (error) {
+			if (__DEV__) console.warn('[sync] pullMissingRoutes failed:', error.message);
+			return;
+		}
+		if (!remoteRoutes?.length) return;
+
+		const localRemoteIds = new Set(listLocalRemoteIds());
+
+		for (const remote of remoteRoutes) {
+			if (localRemoteIds.has(remote.id)) continue; // already have it
+
+			insertRemoteRoute({
+				remoteId: remote.id,
+				name: remote.name,
+				waypoints: remote.waypoints as Waypoint[],
+				geometry: remote.geometry as Feature<LineString>,
+				stats: remote.stats as RouteStats | null,
+				createdAt: remote.created_at,
+			});
+		}
+	} catch (err) {
+		if (__DEV__) console.warn('[sync] pullMissingRoutes exception:', err);
+	}
+}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -1,0 +1,23 @@
+import type { Session, User } from '@supabase/supabase-js';
+import { create } from 'zustand';
+
+interface AuthState {
+	user: User | null;
+	session: Session | null;
+	/** True while the initial session restore is in flight */
+	isLoading: boolean;
+}
+
+interface AuthActions {
+	setSession: (session: Session | null) => void;
+	setLoading: (loading: boolean) => void;
+}
+
+export const useAuthStore = create<AuthState & AuthActions>((set) => ({
+	user: null,
+	session: null,
+	isLoading: true,
+
+	setSession: (session) => set({ session, user: session?.user ?? null }),
+	setLoading: (isLoading) => set({ isLoading }),
+}));

--- a/supabase/migrations/20260323000000_create_routes.sql
+++ b/supabase/migrations/20260323000000_create_routes.sql
@@ -1,0 +1,54 @@
+-- Migration: create routes table with RLS for cloud backup/sync (issue #18)
+-- Run this in the Supabase SQL editor or via the Supabase CLI.
+
+CREATE TABLE IF NOT EXISTS public.routes (
+	id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+	user_id       UUID        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+	name          TEXT        NOT NULL,
+	waypoints     JSONB       NOT NULL,
+	geometry      JSONB       NOT NULL,
+	stats         JSONB,
+	created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+	updated_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+	deleted_at    TIMESTAMPTZ           -- soft delete; NULL = active
+);
+
+-- Index for fast per-user queries
+CREATE INDEX IF NOT EXISTS routes_user_id_idx ON public.routes (user_id);
+
+-- Automatically bump updated_at on any row change
+CREATE OR REPLACE FUNCTION public.set_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN
+	NEW.updated_at = now();
+	RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE TRIGGER routes_set_updated_at
+BEFORE UPDATE ON public.routes
+FOR EACH ROW EXECUTE FUNCTION public.set_updated_at();
+
+-- Row-level security: users can only see/touch their own rows
+ALTER TABLE public.routes ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "routes: users see own rows"
+	ON public.routes FOR SELECT
+	TO authenticated
+	USING (auth.uid() = user_id);
+
+CREATE POLICY "routes: users insert own rows"
+	ON public.routes FOR INSERT
+	TO authenticated
+	WITH CHECK (auth.uid() = user_id);
+
+CREATE POLICY "routes: users update own rows"
+	ON public.routes FOR UPDATE
+	TO authenticated
+	USING (auth.uid() = user_id)
+	WITH CHECK (auth.uid() = user_id);
+
+-- Note: hard DELETEs are not used — soft-delete via deleted_at is preferred.
+-- Add a DELETE policy only if you need it for cleanup jobs:
+-- CREATE POLICY "routes: users delete own rows"
+--   ON public.routes FOR DELETE TO authenticated USING (auth.uid() = user_id);


### PR DESCRIPTION
Local-first strategy: SQLite writes succeed immediately; Supabase calls are fire-and-forget and never surface errors to the user.

- supabase/migrations/20260323000000_create_routes.sql — routes table, RLS policies, updated_at trigger (run in Supabase SQL editor)
- src/services/supabase.ts — client init with SecureStore session adapter
- src/services/authService.ts — email/password sign-in/out, session restore
- src/services/syncService.ts — pushRoute (upsert), pullMissingRoutes, deleteRouteInCloud
- src/store/authStore.ts — Zustand store tracking session/user
- src/services/db.ts — add remote_id, deleted_at, updated_at columns via idempotent ALTER TABLE; soft delete; sync helper functions
- src/components/AccountModal.tsx — sign-in / sign-out bottom sheet
- ControlsPanel.tsx — account button, cloud delete on route removal
- RouteActionBar.tsx — fire-and-forget pushRoute after saveRoute
- App.tsx — AuthBootstrap restores session and subscribes to auth changes
- .env.example + package.json updated with new deps

https://claude.ai/code/session_01HWfF1dy8k8QBxXPYFTpCeY