### PR TITLE
fix: only show unsaved changes modal when route, title, or color changed

### DIFF
--- a/src/components/ControlsPanel.tsx
+++ b/src/components/ControlsPanel.tsx
@@ -26,6 +26,7 @@ import {
 } from '../constants/map';
 import {
 	deleteRoute,
+	getRoute,
 	initDb,
 	listRoutes,
 	type SavedRoute,
@@ -289,8 +290,22 @@ export default function ControlsPanel({ mapViewRef }: Props) {
 
 	// ── Edit mode: back (leave guard) ───────────────────────────────────────────
 	const handleEditBack = useCallback(() => {
-		setLeaveGuardVisible(true);
-	}, []);
+		if (activeRouteId) {
+			const saved = getRoute(activeRouteId);
+			if (saved) {
+				const hasChanges =
+					editingRouteName !== saved.name ||
+					routeColor !== saved.color ||
+					JSON.stringify(waypoints) !== JSON.stringify(saved.waypoints);
+				if (hasChanges) {
+					setLeaveGuardVisible(true);
+					return;
+				}
+			}
+		}
+		clearAll();
+		setEditingMode('view');
+	}, [activeRouteId, editingRouteName, routeColor, waypoints, clearAll, setEditingMode]);
 
 	const handleLeaveGuardContinue = useCallback(() => {
 		setLeaveGuardVisible(false);


### PR DESCRIPTION
Compare current editing state against the saved DB record in handleEditBack before showing the leave guard modal; exit silently if nothing has changed.