### PR TITLE
feat: add register screen and sync status to account sheet

### DIFF
--- a/src/components/AccountModal.tsx
+++ b/src/components/AccountModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
 	ActivityIndicator,
 	Alert,
@@ -11,8 +11,13 @@ import {
 	TouchableOpacity,
 	View,
 } from 'react-native';
-import { signIn, signOut } from '../services/authService';
-import { pullMissingRoutes, pullSettings } from '../services/syncService';
+import { signIn, signOut, signUp } from '../services/authService';
+import { countUnsyncedRoutes } from '../services/db';
+import {
+	pullMissingRoutes,
+	pullSettings,
+	syncAllPending,
+} from '../services/syncService';
 import { useAuthStore } from '../store/authStore';
 import { useSettingsStore } from '../store/settingsStore';
 import type { UnitSystem } from '../utils/units';
@@ -32,9 +37,32 @@ export default function AccountModal({
 	const user = useAuthStore((s) => s.user);
 	const setUnitSystem = useSettingsStore((s) => s.setUnitSystem);
 
+	const [mode, setMode] = useState<'signin' | 'register'>('signin');
 	const [email, setEmail] = useState('');
 	const [password, setPassword] = useState('');
+	const [confirmPassword, setConfirmPassword] = useState('');
 	const [isBusy, setIsBusy] = useState(false);
+	const [isSyncing, setIsSyncing] = useState(false);
+	const [unsyncedCount, setUnsyncedCount] = useState(0);
+
+	// Refresh unsynced count whenever the sheet opens while signed in
+	useEffect(() => {
+		if (visible && user) {
+			setUnsyncedCount(countUnsyncedRoutes());
+		}
+	}, [visible, user]);
+
+	const switchMode = (next: 'signin' | 'register') => {
+		setMode(next);
+		setEmail('');
+		setPassword('');
+		setConfirmPassword('');
+	};
+
+	const handleClose = () => {
+		switchMode('signin');
+		onClose();
+	};
 
 	const handleSignIn = async () => {
 		if (!email.trim() || !password) {
@@ -66,6 +94,38 @@ export default function AccountModal({
 		}
 	};
 
+	const handleRegister = async () => {
+		if (!email.trim() || !password || !confirmPassword) {
+			Alert.alert('Missing fields', 'Please fill in all fields.');
+			return;
+		}
+		if (password !== confirmPassword) {
+			Alert.alert('Password mismatch', 'Passwords do not match.');
+			return;
+		}
+		setIsBusy(true);
+		try {
+			const result = await signUp(email.trim(), password);
+			if (result.error) {
+				Alert.alert('Registration failed', result.error);
+				return;
+			}
+			onClose();
+		} finally {
+			setIsBusy(false);
+		}
+	};
+
+	const handleSyncNow = async () => {
+		setIsSyncing(true);
+		try {
+			await syncAllPending();
+			setUnsyncedCount(countUnsyncedRoutes());
+		} finally {
+			setIsSyncing(false);
+		}
+	};
+
 	const handleSignOut = async () => {
 		setIsBusy(true);
 		try {
@@ -81,23 +141,48 @@ export default function AccountModal({
 			visible={visible}
 			animationType="slide"
 			transparent
-			onRequestClose={onClose}
+			onRequestClose={handleClose}
 		>
 			<KeyboardAvoidingView
 				style={styles.overlay}
 				behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
 			>
 				<View style={styles.sheet}>
-					<Text style={styles.title}>Account</Text>
+					<Text style={styles.title}>
+						{user
+							? 'Account'
+							: mode === 'signin'
+								? 'Sign In'
+								: 'Create Account'}
+					</Text>
 
 					{user ? (
 						// ── Signed-in state ──────────────────────────────────────
 						<>
 							<Text style={styles.emailLabel}>Signed in as</Text>
 							<Text style={styles.email}>{user.email}</Text>
-							<Text style={styles.hint}>
-								Routes are backed up automatically when you save them.
-							</Text>
+
+							<View style={styles.syncRow}>
+								<Text style={styles.syncStatus}>
+									{unsyncedCount === 0
+										? 'All routes backed up'
+										: `${unsyncedCount} route${unsyncedCount === 1 ? '' : 's'} not yet synced`}
+								</Text>
+								{unsyncedCount > 0 && (
+									<TouchableOpacity
+										style={styles.syncButton}
+										onPress={handleSyncNow}
+										disabled={isSyncing}
+									>
+										{isSyncing ? (
+											<ActivityIndicator color="#2563eb" size="small" />
+										) : (
+											<Text style={styles.syncButtonText}>Sync now</Text>
+										)}
+									</TouchableOpacity>
+								)}
+							</View>
+
 							<TouchableOpacity
 								style={[styles.button, styles.destructive]}
 								onPress={handleSignOut}
@@ -114,8 +199,9 @@ export default function AccountModal({
 						// ── Signed-out state ─────────────────────────────────────
 						<>
 							<Text style={styles.hint}>
-								Sign in to back up your routes to the cloud and sync across
-								devices.
+								{mode === 'signin'
+									? 'Sign in to back up your routes to the cloud and sync across devices.'
+									: 'Create an account to back up and sync your routes.'}
 							</Text>
 							<TextInput
 								style={styles.input}
@@ -136,23 +222,49 @@ export default function AccountModal({
 								onChangeText={setPassword}
 								editable={!isBusy}
 							/>
+							{mode === 'register' && (
+								<TextInput
+									style={styles.input}
+									placeholder="Confirm Password"
+									placeholderTextColor="#9ca3af"
+									secureTextEntry
+									value={confirmPassword}
+									onChangeText={setConfirmPassword}
+									editable={!isBusy}
+								/>
+							)}
 							<TouchableOpacity
 								style={styles.button}
-								onPress={handleSignIn}
+								onPress={mode === 'signin' ? handleSignIn : handleRegister}
 								disabled={isBusy}
 							>
 								{isBusy ? (
 									<ActivityIndicator color="#fff" />
 								) : (
-									<Text style={styles.buttonText}>Sign in</Text>
+									<Text style={styles.buttonText}>
+										{mode === 'signin' ? 'Sign in' : 'Create Account'}
+									</Text>
 								)}
+							</TouchableOpacity>
+							<TouchableOpacity
+								style={styles.toggleButton}
+								onPress={() =>
+									switchMode(mode === 'signin' ? 'register' : 'signin')
+								}
+								disabled={isBusy}
+							>
+								<Text style={styles.toggleText}>
+									{mode === 'signin'
+										? "Don't have an account? Create one"
+										: 'Already have an account? Sign in'}
+								</Text>
 							</TouchableOpacity>
 						</>
 					)}
 
 					<TouchableOpacity
 						style={styles.cancelButton}
-						onPress={onClose}
+						onPress={handleClose}
 						disabled={isBusy}
 					>
 						<Text style={styles.cancelText}>Cancel</Text>
@@ -229,5 +341,42 @@ const styles = StyleSheet.create({
 	cancelText: {
 		fontSize: 14,
 		color: '#6b7280',
+	},
+	toggleButton: {
+		alignItems: 'center',
+		paddingVertical: 4,
+	},
+	toggleText: {
+		fontSize: 13,
+		color: '#2563eb',
+	},
+	syncRow: {
+		flexDirection: 'row',
+		alignItems: 'center',
+		justifyContent: 'space-between',
+		paddingVertical: 8,
+		paddingHorizontal: 12,
+		backgroundColor: '#f9fafb',
+		borderRadius: 8,
+	},
+	syncStatus: {
+		fontSize: 13,
+		color: '#374151',
+		flex: 1,
+	},
+	syncButton: {
+		marginLeft: 12,
+		paddingHorizontal: 12,
+		paddingVertical: 6,
+		borderRadius: 6,
+		borderWidth: 1,
+		borderColor: '#2563eb',
+		minWidth: 80,
+		alignItems: 'center',
+	},
+	syncButtonText: {
+		fontSize: 13,
+		color: '#2563eb',
+		fontWeight: '600',
 	},
 });

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -23,6 +23,19 @@ export async function signIn(
 	};
 }
 
+/** Register a new user with email + password. */
+export async function signUp(
+	email: string,
+	password: string,
+): Promise<AuthResult> {
+	const { data, error } = await supabase.auth.signUp({ email, password });
+	return {
+		user: data.user,
+		session: data.session,
+		error: error?.message ?? null,
+	};
+}
+
 /** Sign out and clear the persisted session. */
 export async function signOut(): Promise<void> {
 	await supabase.auth.signOut();

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -255,6 +255,24 @@ export function markRouteSynced(localId: number, remoteId: string): void {
 	db.runSync('UPDATE routes SET remote_id = ? WHERE id = ?', remoteId, localId);
 }
 
+/** Count of local routes not yet pushed to Supabase. */
+export function countUnsyncedRoutes(): number {
+	const db = getDb();
+	const row = db.getFirstSync<{ n: number }>(
+		'SELECT COUNT(*) AS n FROM routes WHERE remote_id IS NULL AND deleted_at IS NULL',
+	);
+	return row?.n ?? 0;
+}
+
+/** Local IDs of routes not yet pushed to Supabase. */
+export function listUnsyncedRouteIds(): number[] {
+	const db = getDb();
+	const rows = db.getAllSync<{ id: number }>(
+		'SELECT id FROM routes WHERE remote_id IS NULL AND deleted_at IS NULL',
+	);
+	return rows.map((r) => r.id);
+}
+
 /** All remote_ids that already exist locally (for dedup during pull). */
 export function listLocalRemoteIds(): string[] {
 	const db = getDb();

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -11,6 +11,7 @@ import {
 	getSettingRow,
 	insertRemoteRoute,
 	listLocalRemoteIds,
+	listUnsyncedRouteIds,
 	markRouteSynced,
 	setSetting,
 } from './db';
@@ -73,6 +74,16 @@ export async function deleteRouteInCloud(remoteId: string): Promise<void> {
 	} catch (err) {
 		if (__DEV__) console.warn('[sync] deleteRouteInCloud exception:', err);
 	}
+}
+
+/**
+ * Push all local routes that have not yet been synced to Supabase.
+ * Returns the number of routes pushed successfully.
+ */
+export async function syncAllPending(): Promise<number> {
+	const ids = listUnsyncedRouteIds();
+	await Promise.all(ids.map((id) => pushRoute(id)));
+	return ids.length;
 }
 
 /**


### PR DESCRIPTION
- Add signUp to authService; AccountModal toggles between sign-in and register views (email, password, confirm password)
- Add countUnsyncedRoutes / listUnsyncedRouteIds to db.ts
- Add syncAllPending to syncService; pushes all unsynced routes in parallel
- Account sheet (signed-in) shows backed-up status and a Sync now button when unsynced routes exist