### PR TITLE
feat: sync route color to Supabase, closes #51

### DIFF
--- a/docs/data.md
+++ b/docs/data.md
@@ -35,6 +35,7 @@ interface RouteForSync {
   localId: number;
   remoteId: string | null;  // Supabase UUID, null until first sync
   name: string;
+  color: string;
   waypoints: Waypoint[];
   geometry: Feature<LineString>;
   stats: RouteStats | null;
@@ -124,8 +125,7 @@ All functions are synchronous (expo-sqlite sync API).
 | `created_at` | `timestamptz` | |
 | `updated_at` | `timestamptz` | |
 | `deleted_at` | `timestamptz \| null` | Soft-delete |
-
-**Known gap:** `color` exists in SQLite but is not in the Supabase `routes` table. Color is not synced.
+| `color` | `text NOT NULL DEFAULT '#3b82f6'` | Hex line colour |
 
 ### `user_settings`
 

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -17,6 +17,7 @@ export interface RouteForSync {
 	localId: number;
 	remoteId: string | null;
 	name: string;
+	color: string;
 	waypoints: Waypoint[];
 	geometry: Feature<LineString>;
 	stats: RouteStats | null;
@@ -230,6 +231,7 @@ export function getRouteForSync(localId: number): RouteForSync | null {
 		id: number;
 		remote_id: string | null;
 		name: string;
+		color: string;
 		waypoints: string;
 		geometry: string;
 		stats: string | null;
@@ -241,6 +243,7 @@ export function getRouteForSync(localId: number): RouteForSync | null {
 		localId: row.id,
 		remoteId: row.remote_id,
 		name: row.name,
+		color: row.color ?? '#3b82f6',
 		waypoints: JSON.parse(row.waypoints) as Waypoint[],
 		geometry: JSON.parse(row.geometry) as Feature<LineString>,
 		stats: row.stats ? (JSON.parse(row.stats) as RouteStats) : null,
@@ -289,6 +292,7 @@ export function listLocalRemoteIds(): string[] {
 export function insertRemoteRoute(route: {
 	remoteId: string;
 	name: string;
+	color: string;
 	waypoints: Waypoint[];
 	geometry: Feature<LineString>;
 	stats: RouteStats | null;
@@ -304,9 +308,10 @@ export function insertRemoteRoute(route: {
 	const now = new Date().toISOString();
 	db.runSync(
 		`INSERT INTO routes
-			(name, waypoints, geometry, stats, created_at, updated_at, remote_id)
-			VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			(name, color, waypoints, geometry, stats, created_at, updated_at, remote_id)
+			VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
 		route.name,
+		route.color,
 		JSON.stringify(route.waypoints),
 		JSON.stringify(route.geometry),
 		route.stats ? JSON.stringify(route.stats) : null,

--- a/src/services/supabase.ts
+++ b/src/services/supabase.ts
@@ -39,6 +39,7 @@ export interface SupabaseRoute {
 	created_at: string;
 	updated_at: string;
 	deleted_at: string | null;
+	color: string;
 }
 
 /** Row shape for the Supabase `user_settings` table. */

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -34,6 +34,7 @@ export async function pushRoute(localId: number): Promise<void> {
 			...(row.remoteId ? { id: row.remoteId } : {}),
 			user_id: userData.user.id,
 			name: row.name,
+			color: row.color,
 			waypoints: row.waypoints,
 			geometry: row.geometry,
 			stats: row.stats,
@@ -117,6 +118,7 @@ export async function pullMissingRoutes(): Promise<void> {
 			insertRemoteRoute({
 				remoteId: remote.id,
 				name: remote.name,
+				color: remote.color ?? '#3b82f6',
 				waypoints: remote.waypoints as Waypoint[],
 				geometry: remote.geometry as Feature<LineString>,
 				stats: remote.stats as RouteStats | null,

--- a/supabase/migrations/20260324000000_add_color_to_routes.sql
+++ b/supabase/migrations/20260324000000_add_color_to_routes.sql
@@ -1,0 +1,5 @@
+-- Migration: add color column to routes table (issue #51)
+-- Run this in the Supabase SQL editor or via the Supabase CLI.
+
+ALTER TABLE public.routes
+	ADD COLUMN IF NOT EXISTS color TEXT NOT NULL DEFAULT '#3b82f6';


### PR DESCRIPTION
Add color column to Supabase routes table (migration), include it in push payload via RouteForSync, and restore it on pull via insertRemoteRoute.